### PR TITLE
Mateo/emld 746 admin routing bug

### DIFF
--- a/frontend/src/lib/features/nft-treasury/components/nft-collections-list/NFTCollectionSelectedCard.svelte
+++ b/frontend/src/lib/features/nft-treasury/components/nft-collections-list/NFTCollectionSelectedCard.svelte
@@ -2,24 +2,12 @@
 	import NFTCollectionSelectCard from './NFTCollectionSelectCard.svelte';
 	import Icon from '@iconify/svelte';
 	import type { NftCollection } from '$lib/features/nft-treasury/types/nft-collection.interface.js';
-	import type { Writable } from 'svelte/store';
-	import { getContext } from 'svelte';
-	import type {
-		DAOProject,
-		DaoDatabaseData
-	} from '$lib/types/dao-project/dao-project.interface.js';
+	import type { DAOProject } from '$lib/types/dao-project/dao-project.interface.js';
 	import { removeAllowedNFTCollections } from '../../../../../routes/admin/[projectId]/nft-collections/_actions/removeAllowedNFTCollections';
 
 	export let nftCollection: NftCollection;
 	export let selectedCollections: string[];
-
-	const adminData: {
-		activeDao: Writable<DAOProject>;
-		otherDaos: DaoDatabaseData[];
-	} = getContext('admin-data');
-
-	const activeDaoStore = adminData.activeDao;
-	$: activeDaoData = $activeDaoStore;
+	export let daoData: DAOProject;
 </script>
 
 <NFTCollectionSelectCard {nftCollection} bind:selectedCollections isCollectionActive={true}>
@@ -29,14 +17,14 @@
 		on:click={() =>
 			removeAllowedNFTCollections(
 				[nftCollection.identifier],
-				activeDaoData.generalInfo.owner,
-				activeDaoData.generalInfo.project_id
+				daoData.generalInfo.owner,
+				daoData.generalInfo.project_id
 			)}
 		on:keydown={() =>
 			removeAllowedNFTCollections(
 				[nftCollection.identifier],
-				activeDaoData.generalInfo.owner,
-				activeDaoData.generalInfo.project_id
+				daoData.generalInfo.owner,
+				daoData.generalInfo.project_id
 			)}
 	>
 		<Icon icon="tabler:x" width="20" height="20" />

--- a/frontend/src/routes/_components/sections/hero-section/HeroSection.svelte
+++ b/frontend/src/routes/_components/sections/hero-section/HeroSection.svelte
@@ -1,5 +1,4 @@
 <script type="ts">
-	import BuiltOnFlow from './atoms/BuiltOnFlow.svelte';
 	import { Button } from '@emerald-dao/component-library';
 	import FeatureLabel from '../atoms/FeatureLabel.svelte';
 </script>
@@ -18,7 +17,7 @@
 				and <FeatureLabel icon="mdi:vote">Voting</FeatureLabel>.
 			</p>
 			<p>
-				Manage funds thorough a secure <FeatureLabel icon="mdi:treasure-chest"
+				Manage funds through a secure <FeatureLabel icon="mdi:treasure-chest"
 					>Multisig Treasury</FeatureLabel
 				>.
 			</p>
@@ -29,7 +28,6 @@
 		>
 		<Button color="primary" size="large" width="extended" href="/dao-generator">Create DAO</Button>
 	</div>
-	<!-- <BuiltOnFlow /> -->
 </section>
 
 <style type="scss">

--- a/frontend/src/routes/admin/+layout.svelte
+++ b/frontend/src/routes/admin/+layout.svelte
@@ -1,7 +1,37 @@
 <script lang="ts">
 	import OpenGraph from '$components/OpenGraph.svelte';
+	import { Button } from '@emerald-dao/component-library';
+	import { user } from '$stores/flow/FlowStore';
+	import ConnectPage from '$components/atoms/ConnectPage.svelte';
+	import { invalidate } from '$app/navigation';
+	import DesktopOnlyPage from '$components/desktop-only-page/DesktopOnlyPage.svelte';
+
+	export let data;
+
+	let screenSize: number;
+
+	const onChangeUser = async () => {
+		await invalidate('app:admin');
+	};
+
+	$: $user.addr && onChangeUser();
 </script>
 
 <OpenGraph title="Admin" />
 
-<slot />
+<svelte:window bind:innerWidth={screenSize} />
+
+{#if screenSize < 1040}
+	<DesktopOnlyPage />
+{:else if !$user.addr}
+	<ConnectPage />
+{:else if data.daos.length > 0}
+	<slot />
+{:else}
+	<section class="container flex centered">
+		<div class="card-primary column-7 align-center">
+			<span>You do not have any DAOs to manage.</span>
+			<Button size="large" href="/dao-generator">Create DAO</Button>
+		</div>
+	</section>
+{/if}

--- a/frontend/src/routes/admin/+layout.ts
+++ b/frontend/src/routes/admin/+layout.ts
@@ -1,0 +1,24 @@
+import { supabase } from '$lib/supabaseClient.js';
+import { get } from 'svelte/store';
+import { user } from '$stores/flow/FlowStore';
+import { network } from '$flow/config';
+
+export const load = async ({ depends }) => {
+	depends('app:admin');
+
+	if (get(user).loggedIn) {
+		const { data } = await supabase
+			.from('projects')
+			.select()
+			.eq('owner', get(user).addr)
+			.eq('network', network);
+
+		return {
+			daos: data || []
+		};
+	}
+
+	return {
+		daos: []
+	};
+};

--- a/frontend/src/routes/admin/+page.ts
+++ b/frontend/src/routes/admin/+page.ts
@@ -1,20 +1,19 @@
-import { network } from '$flow/config';
-import { supabase } from '$lib/supabaseClient';
 import { user } from '$stores/flow/FlowStore';
 import { redirect } from '@sveltejs/kit';
 import { get } from 'svelte/store';
 
 export const ssr = false;
 
-export async function load({ depends }) {
-    depends('app:admin');
-    if (get(user).loggedIn) {
-        const { data } = await supabase.from('projects').select().eq('owner', get(user).addr).eq('network', network);
+export async function load({ depends, parent }) {
+	depends('app:admin');
+	if (get(user).loggedIn) {
+		const { daos } = await parent();
 
-        if (!data || !data.length) {
-            return {}
-        }
-        throw redirect(302, `/admin/${data[0].project_id}`);
-    }
-    return {}
+		if (!daos || !daos.length) {
+			return {};
+		}
+
+		throw redirect(302, `/admin/${daos[0].project_id}`);
+	}
+	return {};
 }

--- a/frontend/src/routes/admin/[projectId]/+layout.svelte
+++ b/frontend/src/routes/admin/[projectId]/+layout.svelte
@@ -31,12 +31,6 @@
 
 		return () => supabase.removeChannel(subscription);
 	});
-
-	const onChangeUser = async () => {
-		await invalidate('app:admin');
-	};
-
-	$: $user.addr && onChangeUser();
 </script>
 
 <svelte:window bind:innerWidth={screenSize} />

--- a/frontend/src/routes/admin/[projectId]/+layout.ts
+++ b/frontend/src/routes/admin/[projectId]/+layout.ts
@@ -1,51 +1,41 @@
-import type { LayoutLoad } from '../$types';
-import { supabase } from '$lib/supabaseClient';
 import { getProjectInfo } from '$flow/actions';
-import '$flow/config.ts';
 import { user } from '$stores/flow/FlowStore';
 import { get } from 'svelte/store';
 import type { DAOProject, DaoDatabaseData } from '$lib/types/dao-project/dao-project.interface';
 import { fetchProjectEvents } from '$lib/utilities/api/supabase/fetchProjectEvents';
-import { network } from '$flow/config';
 import { fetchDaoFundingInfo } from '$lib/utilities/api/supabase/fetchDaoFundingInfo';
+import { redirect } from '@sveltejs/kit';
 
 export const ssr = false;
+
+export const load = async ({ depends, params, parent }) => {
+	depends('app:admin');
+
+	if (get(user).loggedIn) {
+		const { daos } = await parent();
+
+		const daoId = params.projectId;
+		const daoGeneralInfo = daos.find((dao) => dao.project_id === daoId) as DaoDatabaseData;
+		const daoData: DAOProject = await fetchProjectData(daoGeneralInfo);
+
+		if (daoData.onChainData.signers.includes(get(user).addr as string)) {
+			return {
+				activeDao: daoData
+			};
+		}
+
+		redirect(300, '/admin');
+	}
+
+	redirect(300, '/admin');
+};
 
 async function fetchProjectData(project: DaoDatabaseData): Promise<DAOProject> {
 	return {
 		generalInfo: project,
-		onChainData: await getProjectInfo(
-			project.contract_address,
-			project.owner,
-			project.project_id
-		),
+		onChainData: await getProjectInfo(project.contract_address, project.owner, project.project_id),
 		events: await fetchProjectEvents(project.project_id),
 		hasToken: project.contract_address !== null,
 		funding: await fetchDaoFundingInfo(project.project_id)
-	}
+	};
 }
-
-export const load: LayoutLoad = async ({ depends, params }) => {
-	depends('app:admin');
-
-	if (get(user).loggedIn) {
-		const { data } = await supabase.from('projects').select().eq('project_id', params.projectId).eq('network', network)
-		if (!data || !data.length) {
-			return {
-				activeDao: null,
-				otherDaos: []
-			};
-		}
-		const { data: ownedProjects } = await supabase.from('projects').select().eq('owner', get(user).addr).eq('network', network).neq('project_id', params.projectId);
-
-		const daoDatabaseData: DaoDatabaseData = data[0];
-		const daoData: DAOProject = await fetchProjectData(daoDatabaseData);
-		if (daoData.onChainData.signers.includes(get(user).addr)) {
-			return {
-				activeDao: daoData,
-				otherDaos: ownedProjects || [],
-			};
-		}
-	}
-	return { activeDao: null, otherDaos: [] };
-};

--- a/frontend/src/routes/admin/[projectId]/+layout.ts
+++ b/frontend/src/routes/admin/[projectId]/+layout.ts
@@ -10,6 +10,7 @@ export const ssr = false;
 
 export const load = async ({ depends, params, parent }) => {
 	depends('app:admin');
+	depends('app:dao-data');
 
 	if (get(user).loggedIn) {
 		const { daos } = await parent();

--- a/frontend/src/routes/admin/[projectId]/+layout.ts
+++ b/frontend/src/routes/admin/[projectId]/+layout.ts
@@ -17,18 +17,16 @@ export const load = async ({ depends, params, parent }) => {
 
 		const daoId = params.projectId;
 		const daoGeneralInfo = daos.find((dao) => dao.project_id === daoId) as DaoDatabaseData;
-		const daoData: DAOProject = await fetchProjectData(daoGeneralInfo);
+		const daoData = await fetchProjectData(daoGeneralInfo);
 
 		if (daoData.onChainData.signers.includes(get(user).addr as string)) {
 			return {
 				activeDao: daoData
 			};
 		}
-
-		redirect(300, '/admin');
 	}
 
-	redirect(300, '/admin');
+	throw redirect(300, '/admin');
 };
 
 async function fetchProjectData(project: DaoDatabaseData): Promise<DAOProject> {

--- a/frontend/src/routes/admin/[projectId]/+page.svelte
+++ b/frontend/src/routes/admin/[projectId]/+page.svelte
@@ -1,7 +1,4 @@
 <script lang="ts">
-	import type { DAOProject, DaoDatabaseData } from '$lib/types/dao-project/dao-project.interface';
-	import { getContext } from 'svelte';
-	import type { Writable } from 'svelte/store';
 	import {
 		PrimaryTabs,
 		SecondaryTabs,
@@ -12,33 +9,29 @@
 	} from './_components';
 	import * as AdminPage from './_components/admin-page';
 
-	const adminData: {
-		activeDao: Writable<DAOProject>;
-		otherDaos: DaoDatabaseData[];
-	} = getContext('admin-data');
-
-	const activeDaoStore = adminData.activeDao;
-	$: activeDaoData = $activeDaoStore;
+	export let data;
 </script>
 
-<AdminPage.Root>
-	<DaoStatsIntro daoData={activeDaoData} />
-	<div class="secondary-wrapper">
-		<div class="column-8">
-			<GeneralStats daoData={activeDaoData} />
-			<PrimaryTabs daoData={activeDaoData} />
-		</div>
-		<div class="column-space-between second-column">
-			<div class="treasury-wrapper column-6">
-				<a href={`/admin/${activeDaoData.generalInfo.project_id}/withdraw`}>
-					<TreasuryWallet daoData={activeDaoData} />
-				</a>
-				<SecondaryTabs daoData={activeDaoData} />
+{#if data.activeDao}
+	<AdminPage.Root>
+		<DaoStatsIntro daoData={data.activeDao} />
+		<div class="secondary-wrapper">
+			<div class="column-8">
+				<GeneralStats daoData={data.activeDao} />
+				<PrimaryTabs daoData={data.activeDao} />
 			</div>
-			<Signers daoData={activeDaoData} />
+			<div class="column-space-between second-column">
+				<div class="treasury-wrapper column-6">
+					<a href={`/admin/${data.activeDao.generalInfo.project_id}/withdraw`}>
+						<TreasuryWallet daoData={data.activeDao} />
+					</a>
+					<SecondaryTabs daoData={data.activeDao} />
+				</div>
+				<Signers daoData={data.activeDao} />
+			</div>
 		</div>
-	</div>
-</AdminPage.Root>
+	</AdminPage.Root>
+{/if}
 
 <style lang="scss">
 	.secondary-wrapper {

--- a/frontend/src/routes/admin/[projectId]/_components/navigation/AdminNav.svelte
+++ b/frontend/src/routes/admin/[projectId]/_components/navigation/AdminNav.svelte
@@ -1,29 +1,22 @@
 <script type="ts">
 	import { fly } from 'svelte/transition';
-	import type { DAOProject, DaoDatabaseData } from '$lib/types/dao-project/dao-project.interface';
 	import { page } from '$app/stores';
 	import { Label, AlertNumber } from '@emerald-dao/component-library';
 	import Icon from '@iconify/svelte';
-	import { getContext } from 'svelte';
-	import type { Writable } from 'svelte/store';
 	import DropDownHeading from './atoms/DropDownHeading.svelte';
 	import CopyToClipboard from '$components/atoms/CopyToClipboard.svelte';
 	import { handleLogoImgError } from '$lib/utilities/handleLogoImgError';
 	import { network } from '$flow/config';
+	import type { DAOProject, DaoDatabaseData } from '$lib/types/dao-project/dao-project.interface';
 
-	const adminData: {
-		activeDao: Writable<DAOProject>;
-		otherDaos: DaoDatabaseData[];
-	} = getContext('admin-data');
-
-	const activeDaoStore = adminData.activeDao;
-	$: activeDaoData = $activeDaoStore;
+	export let activeDao: DAOProject;
+	export let daos: DaoDatabaseData[];
 
 	let copied = false;
 	const copyToClipboard = () => {
 		const app = new CopyToClipboard({
 			target: document.getElementById('clipboard') as Element,
-			props: { name: `${$page.url.origin}/p/${activeDaoData.generalInfo.project_id}` }
+			props: { name: `${$page.url.origin}/p/${activeDao.generalInfo.project_id}` }
 		});
 
 		copied = true;
@@ -40,17 +33,17 @@
 	<div class="column-6">
 		<div class="row-3 align-center">
 			<img
-				src={activeDaoData.generalInfo.logo}
+				src={activeDao.generalInfo.logo}
 				on:error={(e) => handleLogoImgError(e)}
 				alt="DAO Logo"
 			/>
-			<DropDownHeading activeDao={activeDaoData} userDaos={adminData.otherDaos}>
+			<DropDownHeading {activeDao} {daos}>
 				<div id="clipboard" />
 				<div class="top-dropdown-wapper" on:click={copyToClipboard} slot="top" on:keydown>
 					<Label color="neutral" size="small">
 						<div class="row-6 header-link align-center">
 							<span class="row-1 align-center">
-								{activeDaoData.generalInfo.project_id}
+								{activeDao.generalInfo.project_id}
 							</span>
 							{#if copied}
 								<div in:fly|local={{ x: 10, duration: 300 }} class="row align-center">
@@ -74,9 +67,9 @@
 		</div>
 		<div class="column-4">
 			<a
-				href={`/admin/${activeDaoData.generalInfo.project_id}`}
+				href={`/admin/${activeDao.generalInfo.project_id}`}
 				class="sidebar-link"
-				class:active={$page.url.pathname === `/admin/${activeDaoData.generalInfo.project_id}`}
+				class:active={$page.url.pathname === `/admin/${activeDao.generalInfo.project_id}`}
 			>
 				<div class="sidebar-link-icon">
 					<Icon icon="tabler:home" />
@@ -84,7 +77,7 @@
 				Home
 			</a>
 			<a
-				href={`/admin/${activeDaoData.generalInfo.project_id}/actions`}
+				href={`/admin/${activeDao.generalInfo.project_id}/actions`}
 				class="sidebar-link"
 				class:active={$page.url.pathname.includes('actions')}
 			>
@@ -92,13 +85,13 @@
 					<Icon icon="tabler:layout-list" />
 				</div>
 				Actions Queue
-				{#if Number(activeDaoData.onChainData.actions.length) > 0}
-					<AlertNumber number={Number(activeDaoData.onChainData.actions.length)} />
+				{#if Number(activeDao.onChainData.actions.length) > 0}
+					<AlertNumber number={Number(activeDao.onChainData.actions.length)} />
 				{/if}
 			</a>
-			{#if activeDaoData.hasToken}
+			{#if activeDao.hasToken}
 				<a
-					href={`/admin/${activeDaoData.generalInfo.project_id}/rounds`}
+					href={`/admin/${activeDao.generalInfo.project_id}/rounds`}
 					class="sidebar-link"
 					class:active={$page.url.pathname.includes('rounds')}
 				>
@@ -109,7 +102,7 @@
 				</a>
 			{/if}
 			<a
-				href={`/admin/${activeDaoData.generalInfo.project_id}/multisig`}
+				href={`/admin/${activeDao.generalInfo.project_id}/multisig`}
 				class="sidebar-link"
 				class:active={$page.url.pathname.includes('multisig')}
 			>
@@ -118,9 +111,9 @@
 				</div>
 				Multisig
 			</a>
-			{#if activeDaoData.hasToken}
+			{#if activeDao.hasToken}
 				<a
-					href={`/admin/${activeDaoData.generalInfo.project_id}/overflow`}
+					href={`/admin/${activeDao.generalInfo.project_id}/overflow`}
 					class="sidebar-link"
 					class:active={$page.url.pathname.includes('overflow')}
 				>
@@ -131,7 +124,7 @@
 				</a>
 			{/if}
 			<a
-				href={`/admin/${activeDaoData.generalInfo.project_id}/nft-collections`}
+				href={`/admin/${activeDao.generalInfo.project_id}/nft-collections`}
 				class="sidebar-link"
 				class:active={$page.url.pathname.includes('nft-collections')}
 			>
@@ -141,7 +134,7 @@
 				NFT Collections
 			</a>
 			<a
-				href={`/admin/${activeDaoData.generalInfo.project_id}/voting`}
+				href={`/admin/${activeDao.generalInfo.project_id}/voting`}
 				class="sidebar-link"
 				class:active={$page.url.pathname.includes('voting')}
 			>
@@ -152,7 +145,7 @@
 			</a>
 			<span class="sidebar-divider">Funds management</span>
 			<a
-				href={`/admin/${activeDaoData.generalInfo.project_id}/withdraw`}
+				href={`/admin/${activeDao.generalInfo.project_id}/withdraw`}
 				class="sidebar-link"
 				class:active={$page.url.pathname.includes('withdraw')}
 			>
@@ -161,9 +154,9 @@
 				</div>
 				Distribute
 			</a>
-			{#if activeDaoData.hasToken && activeDaoData.onChainData.minting}
+			{#if activeDao.hasToken && activeDao.onChainData.minting}
 				<a
-					href={`/admin/${activeDaoData.generalInfo.project_id}/mint`}
+					href={`/admin/${activeDao.generalInfo.project_id}/mint`}
 					class="sidebar-link"
 					class:active={$page.url.pathname.includes('mint')}
 				>
@@ -173,9 +166,9 @@
 					Mint
 				</a>
 			{/if}
-			{#if activeDaoData.hasToken}
+			{#if activeDao.hasToken}
 				<a
-					href={`/admin/${activeDaoData.generalInfo.project_id}/lock`}
+					href={`/admin/${activeDao.generalInfo.project_id}/lock`}
 					class="sidebar-link"
 					class:active={$page.url.pathname.includes('lock')}
 				>
@@ -186,7 +179,7 @@
 				</a>
 			{/if}
 			<a
-				href={`/admin/${activeDaoData.generalInfo.project_id}/burn`}
+				href={`/admin/${activeDao.generalInfo.project_id}/burn`}
 				class="sidebar-link"
 				class:active={$page.url.pathname.includes('burn')}
 			>
@@ -197,7 +190,7 @@
 			</a>
 			{#if network === 'mainnet'}
 				<a
-					href={`/admin/${activeDaoData.generalInfo.project_id}/staking`}
+					href={`/admin/${activeDao.generalInfo.project_id}/staking`}
 					class="sidebar-link"
 					class:active={$page.url.pathname.includes('staking')}
 				>
@@ -210,7 +203,7 @@
 		</div>
 	</div>
 	<a
-		href={`/admin/${activeDaoData.generalInfo.project_id}/info`}
+		href={`/admin/${activeDao.generalInfo.project_id}/info`}
 		class="sidebar-link small"
 		class:active={$page.url.pathname.includes('info')}
 	>

--- a/frontend/src/routes/admin/[projectId]/_components/navigation/atoms/DropDownHeading.svelte
+++ b/frontend/src/routes/admin/[projectId]/_components/navigation/atoms/DropDownHeading.svelte
@@ -3,9 +3,8 @@
 	import Icon from '@iconify/svelte';
 	import type { DAOProject, DaoDatabaseData } from '$lib/types/dao-project/dao-project.interface';
 	import { handleLogoImgError } from '$lib/utilities/handleLogoImgError';
-	import { goto } from '$app/navigation';
 
-	export let userDaos: DaoDatabaseData[];
+	export let daos: DaoDatabaseData[];
 	export let activeDao: DAOProject;
 
 	let dropDown: HTMLDivElement;
@@ -46,16 +45,15 @@
 	{#if displayDropDown}
 		<div class="drop-down" bind:this={dropDown} transition:fly|local={{ y: 15, duration: 400 }}>
 			<slot name="top" />
-			{#if userDaos.length > 1}
+			{#if daos.length > 1}
 				<ul>
-					{#each userDaos as dao, index}
+					{#each daos as dao, index}
 						<li>
 							<img src={dao.logo} on:error={(e) => handleLogoImgError(e)} alt="dao logo" />
 							<a
 								class="header-link"
-								class:selected={index === 0}
-								href=""
-								on:click={() => goto(`/admin/${dao.project_id}`)}
+								class:selected={dao.project_id === activeDao.generalInfo.project_id}
+								href={`/admin/${dao.project_id}`}
 							>
 								{dao.name}
 							</a>

--- a/frontend/src/routes/admin/[projectId]/_components/stats-blocks/GeneralStats.svelte
+++ b/frontend/src/routes/admin/[projectId]/_components/stats-blocks/GeneralStats.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import type { DAOProject } from '$lib/types/dao-project/dao-project.interface';
-	import { Currency, Label } from '@emerald-dao/component-library';
+	import { Currency } from '@emerald-dao/component-library';
 
 	export let daoData: DAOProject;
 </script>

--- a/frontend/src/routes/admin/[projectId]/actions/+page.svelte
+++ b/frontend/src/routes/admin/[projectId]/actions/+page.svelte
@@ -1,24 +1,19 @@
 <script type="ts">
-	import type { DAOProject, DaoDatabaseData } from '$lib/types/dao-project/dao-project.interface';
-	import { getContext, onMount } from 'svelte';
-	import type { Writable } from 'svelte/store';
+	import type { DAOProject } from '$lib/types/dao-project/dao-project.interface';
+	import { onMount } from 'svelte';
 	import PendingActionsList from '$lib/components/dao-data-blocks/pending-actions/list/PendingActionsList.svelte';
 	import { getProjectInfo } from '$flow/actions';
 	import * as AdminPage from '../_components/admin-page';
 
-	const adminData: {
-		activeDao: Writable<DAOProject>;
-		otherDaos: DaoDatabaseData[];
-	} = getContext('admin-data');
+	export let data;
 
-	const activeDaoStore = adminData.activeDao;
-	$: activeDaoData = $activeDaoStore;
+	let activeDao = data.activeDao as DAOProject;
 
 	onMount(async () => {
-		activeDaoData.onChainData = await getProjectInfo(
-			activeDaoData.generalInfo.contract_address,
-			activeDaoData.generalInfo.owner,
-			activeDaoData.generalInfo.project_id
+		activeDao.onChainData = await getProjectInfo(
+			activeDao.generalInfo.contract_address,
+			activeDao.generalInfo.owner,
+			activeDao.generalInfo.project_id
 		);
 	});
 </script>
@@ -29,12 +24,12 @@
 		<AdminPage.Description>Actions waiting for signatures</AdminPage.Description>
 	</AdminPage.Header>
 	<AdminPage.Container grid={false}>
-		{#if activeDaoData.onChainData.actions.length < 1}
+		{#if activeDao.onChainData.actions.length < 1}
 			<AdminPage.EmptyMessage
 				>This project has no actions waiting for signatures</AdminPage.EmptyMessage
 			>
 		{:else}
-			<PendingActionsList daoData={activeDaoData} />
+			<PendingActionsList daoData={activeDao} />
 		{/if}
 	</AdminPage.Container>
 </AdminPage.Root>

--- a/frontend/src/routes/admin/[projectId]/actions/+page.svelte
+++ b/frontend/src/routes/admin/[projectId]/actions/+page.svelte
@@ -1,21 +1,8 @@
 <script type="ts">
-	import type { DAOProject } from '$lib/types/dao-project/dao-project.interface';
-	import { onMount } from 'svelte';
 	import PendingActionsList from '$lib/components/dao-data-blocks/pending-actions/list/PendingActionsList.svelte';
-	import { getProjectInfo } from '$flow/actions';
 	import * as AdminPage from '../_components/admin-page';
 
 	export let data;
-
-	let activeDao = data.activeDao as DAOProject;
-
-	onMount(async () => {
-		activeDao.onChainData = await getProjectInfo(
-			activeDao.generalInfo.contract_address,
-			activeDao.generalInfo.owner,
-			activeDao.generalInfo.project_id
-		);
-	});
 </script>
 
 <AdminPage.Root>
@@ -24,12 +11,12 @@
 		<AdminPage.Description>Actions waiting for signatures</AdminPage.Description>
 	</AdminPage.Header>
 	<AdminPage.Container grid={false}>
-		{#if activeDao.onChainData.actions.length < 1}
+		{#if data.activeDao.onChainData.actions.length < 1}
 			<AdminPage.EmptyMessage
 				>This project has no actions waiting for signatures</AdminPage.EmptyMessage
 			>
 		{:else}
-			<PendingActionsList daoData={activeDao} />
+			<PendingActionsList daoData={data.activeDao} />
 		{/if}
 	</AdminPage.Container>
 </AdminPage.Root>

--- a/frontend/src/routes/admin/[projectId]/burn/+page.svelte
+++ b/frontend/src/routes/admin/[projectId]/burn/+page.svelte
@@ -1,24 +1,19 @@
 <script type="ts">
-	import type { Writable } from 'svelte/store';
-	import { getContext, onMount } from 'svelte';
-	import type { DAOProject, DaoDatabaseData } from '$lib/types/dao-project/dao-project.interface';
+	import { onMount } from 'svelte';
+	import type { DAOProject } from '$lib/types/dao-project/dao-project.interface';
 	import * as DistributeTokens from '$lib/features/distribute-tokens/components';
 	import type { Distribution } from '$lib/types/dao-project/funding-rounds/distribution.interface';
 	import BurnTokensForm from './_components/BurnTokensForm.svelte';
 	import * as AdminPage from '../_components/admin-page';
 
-	const adminData: {
-		activeDao: Writable<DAOProject>;
-		otherDaos: DaoDatabaseData[];
-	} = getContext('admin-data');
+	export let data;
 
-	const activeDaoStore = adminData.activeDao;
-	$: activeDaoData = $activeDaoStore;
+	let activeDao = data.activeDao as DAOProject;
 
 	let activeCurrency: string;
 
 	onMount(() => {
-		activeCurrency = Object.keys(activeDaoData.onChainData.treasuryBalances)[0];
+		activeCurrency = Object.keys(activeDao.onChainData.treasuryBalances)[0];
 	});
 
 	let formDist: Distribution = {
@@ -29,7 +24,7 @@
 
 	let distStaging: Distribution[] = [];
 
-	$: availableBalance = Number(activeDaoData.onChainData.treasuryBalances[activeCurrency]);
+	$: availableBalance = Number(activeDao.onChainData.treasuryBalances[activeCurrency]);
 
 	const resetDistribution = () => {
 		formDist = {
@@ -54,13 +49,13 @@
 				</AdminPage.Description>
 			</AdminPage.Header>
 			<DistributeTokens.Tabs>
-				{#each Object.entries(activeDaoData.onChainData.treasuryBalances) as [currency] (currency)}
+				{#each Object.entries(activeDao.onChainData.treasuryBalances) as [currency] (currency)}
 					<DistributeTokens.Tab {currency} bind:activeCurrency />
 				{/each}
 			</DistributeTokens.Tabs>
 			<DistributeTokens.AvailableBalance {availableBalance} currency={activeCurrency} />
-			{#if activeDaoData.onChainData.treasuryBalances[activeCurrency] != undefined && Number(activeDaoData.onChainData.treasuryBalances[activeCurrency]) > 0}
-				<BurnTokensForm {activeCurrency} daoData={activeDaoData} />
+			{#if activeDao.onChainData.treasuryBalances[activeCurrency] != undefined && Number(activeDao.onChainData.treasuryBalances[activeCurrency]) > 0}
+				<BurnTokensForm {activeCurrency} daoData={activeDao} />
 			{:else}
 				<DistributeTokens.NoTokensMessage>
 					{`No ${activeCurrency} tokens available to burn.`}

--- a/frontend/src/routes/admin/[projectId]/burn/+page.svelte
+++ b/frontend/src/routes/admin/[projectId]/burn/+page.svelte
@@ -1,6 +1,5 @@
 <script type="ts">
 	import { onMount } from 'svelte';
-	import type { DAOProject } from '$lib/types/dao-project/dao-project.interface';
 	import * as DistributeTokens from '$lib/features/distribute-tokens/components';
 	import type { Distribution } from '$lib/types/dao-project/funding-rounds/distribution.interface';
 	import BurnTokensForm from './_components/BurnTokensForm.svelte';
@@ -8,12 +7,10 @@
 
 	export let data;
 
-	let activeDao = data.activeDao as DAOProject;
-
 	let activeCurrency: string;
 
 	onMount(() => {
-		activeCurrency = Object.keys(activeDao.onChainData.treasuryBalances)[0];
+		activeCurrency = Object.keys(data.activeDao.onChainData.treasuryBalances)[0];
 	});
 
 	let formDist: Distribution = {
@@ -24,7 +21,7 @@
 
 	let distStaging: Distribution[] = [];
 
-	$: availableBalance = Number(activeDao.onChainData.treasuryBalances[activeCurrency]);
+	$: availableBalance = Number(data.activeDao.onChainData.treasuryBalances[activeCurrency]);
 
 	const resetDistribution = () => {
 		formDist = {
@@ -49,13 +46,13 @@
 				</AdminPage.Description>
 			</AdminPage.Header>
 			<DistributeTokens.Tabs>
-				{#each Object.entries(activeDao.onChainData.treasuryBalances) as [currency] (currency)}
+				{#each Object.entries(data.activeDao.onChainData.treasuryBalances) as [currency] (currency)}
 					<DistributeTokens.Tab {currency} bind:activeCurrency />
 				{/each}
 			</DistributeTokens.Tabs>
 			<DistributeTokens.AvailableBalance {availableBalance} currency={activeCurrency} />
-			{#if activeDao.onChainData.treasuryBalances[activeCurrency] != undefined && Number(activeDao.onChainData.treasuryBalances[activeCurrency]) > 0}
-				<BurnTokensForm {activeCurrency} daoData={activeDao} />
+			{#if data.activeDao.onChainData.treasuryBalances[activeCurrency] != undefined && Number(data.activeDao.onChainData.treasuryBalances[activeCurrency]) > 0}
+				<BurnTokensForm {activeCurrency} daoData={data.activeDao} />
 			{:else}
 				<DistributeTokens.NoTokensMessage>
 					{`No ${activeCurrency} tokens available to burn.`}

--- a/frontend/src/routes/admin/[projectId]/burn/_components/BurnTokensForm.svelte
+++ b/frontend/src/routes/admin/[projectId]/burn/_components/BurnTokensForm.svelte
@@ -1,5 +1,5 @@
 <script type="ts">
-	import { Button, Currency, InputWrapper } from '@emerald-dao/component-library';
+	import { Button, InputWrapper } from '@emerald-dao/component-library';
 	import { burnTokensExecution } from '$flow/actions';
 	import type { DAOProject } from '$lib/types/dao-project/dao-project.interface';
 	import { onMount } from 'svelte';

--- a/frontend/src/routes/admin/[projectId]/info/+page.svelte
+++ b/frontend/src/routes/admin/[projectId]/info/+page.svelte
@@ -1,22 +1,16 @@
 <script type="ts">
-	import type { Writable } from 'svelte/store';
-	import { getContext, onMount } from 'svelte';
-	import type { DAOProject, DaoDatabaseData } from '$lib/types/dao-project/dao-project.interface';
+	import { onMount } from 'svelte';
+	import type { DAOProject } from '$lib/types/dao-project/dao-project.interface';
 	import { Button, InputWrapper, DropZone } from '@emerald-dao/component-library';
 	import validationSuite from './validation';
 	import { applyAction, enhance } from '$app/forms';
 	import IconCircle from '$components/atoms/IconCircle.svelte';
 	import * as AdminPage from '../_components/admin-page';
 
+	export let data;
 	export let form;
 
-	const adminData: {
-		activeDao: Writable<DAOProject>;
-		otherDaos: DaoDatabaseData[];
-	} = getContext('admin-data');
-
-	const activeDaoStore = adminData.activeDao;
-	$: activeDaoData = $activeDaoStore;
+	let activeDao = data.activeDao as DAOProject;
 
 	let changesSubmmited = false;
 	let submitionOnCourse = false;
@@ -41,13 +35,13 @@
 		submitionOnCourse = false;
 		changesSubmmited = true;
 
-		formData.website = (form?.website as string) ?? activeDaoData.generalInfo.website;
-		formData.twitter = (form?.twitter as string) ?? activeDaoData.generalInfo.twitter;
-		formData.discord = (form?.discord as string) ?? activeDaoData.generalInfo.discord;
-		formData.name = (form?.name as string) ?? activeDaoData.generalInfo.name;
-		formData.description = (form?.description as string) ?? activeDaoData.generalInfo.description;
+		formData.website = (form?.website as string) ?? activeDao.generalInfo.website;
+		formData.twitter = (form?.twitter as string) ?? activeDao.generalInfo.twitter;
+		formData.discord = (form?.discord as string) ?? activeDao.generalInfo.discord;
+		formData.name = (form?.name as string) ?? activeDao.generalInfo.name;
+		formData.description = (form?.description as string) ?? activeDao.generalInfo.description;
 		formData.long_description =
-			(form?.long_description as string) ?? activeDaoData.generalInfo.long_description;
+			(form?.long_description as string) ?? activeDao.generalInfo.long_description;
 	};
 
 	const handleChange = (input: Event) => {
@@ -62,25 +56,25 @@
 	};
 
 	const populateFormData = () => {
-		formData.website = activeDaoData.generalInfo.website ? activeDaoData.generalInfo.website : '';
-		formData.twitter = activeDaoData.generalInfo.twitter ? activeDaoData.generalInfo.twitter : '';
-		formData.name = activeDaoData.generalInfo.name ? activeDaoData.generalInfo.name : '';
-		formData.discord = activeDaoData.generalInfo.discord ? activeDaoData.generalInfo.discord : '';
-		formData.description = activeDaoData.generalInfo.description;
-		formData.long_description = activeDaoData.generalInfo.long_description
-			? activeDaoData.generalInfo.long_description
+		formData.website = activeDao.generalInfo.website ? activeDao.generalInfo.website : '';
+		formData.twitter = activeDao.generalInfo.twitter ? activeDao.generalInfo.twitter : '';
+		formData.name = activeDao.generalInfo.name ? activeDao.generalInfo.name : '';
+		formData.discord = activeDao.generalInfo.discord ? activeDao.generalInfo.discord : '';
+		formData.description = activeDao.generalInfo.description;
+		formData.long_description = activeDao.generalInfo.long_description
+			? activeDao.generalInfo.long_description
 			: '';
 	};
 
 	const checkDataChanges = () => {
-		if (activeDaoData) {
+		if (activeDao) {
 			return (
-				formData.website !== activeDaoData.generalInfo.website ||
-				formData.twitter !== activeDaoData.generalInfo.twitter ||
-				formData.discord !== activeDaoData.generalInfo.discord ||
-				formData.name !== activeDaoData.generalInfo.name || 
-				formData.description !== activeDaoData.generalInfo.description ||
-				formData.long_description !== activeDaoData.generalInfo.long_description ||
+				formData.website !== activeDao.generalInfo.website ||
+				formData.twitter !== activeDao.generalInfo.twitter ||
+				formData.discord !== activeDao.generalInfo.discord ||
+				formData.name !== activeDao.generalInfo.name ||
+				formData.description !== activeDao.generalInfo.description ||
+				formData.long_description !== activeDao.generalInfo.long_description ||
 				formData.logo.length > 0 ||
 				formData.bannerImage.length > 0
 			);
@@ -96,9 +90,9 @@
 
 	let res = validationSuite.get();
 
-	$: activeDaoData && populateFormData();
-	$: activeDaoData && formData && (formHasChanges = checkDataChanges());
-	$: activeDaoData && resetValidation();
+	$: activeDao && populateFormData();
+	$: activeDao && formData && (formHasChanges = checkDataChanges());
+	$: activeDao && resetValidation();
 </script>
 
 <AdminPage.Root>
@@ -123,12 +117,7 @@
 			autocomplete="off"
 		>
 			<div>
-				<input
-					type="hidden"
-					name="project_id"
-					hidden
-					value={activeDaoData.generalInfo.project_id}
-				/>
+				<input type="hidden" name="project_id" hidden value={activeDao.generalInfo.project_id} />
 				<InputWrapper
 					name="name"
 					label="Name"

--- a/frontend/src/routes/admin/[projectId]/info/+page.svelte
+++ b/frontend/src/routes/admin/[projectId]/info/+page.svelte
@@ -1,6 +1,5 @@
 <script type="ts">
 	import { onMount } from 'svelte';
-	import type { DAOProject } from '$lib/types/dao-project/dao-project.interface';
 	import { Button, InputWrapper, DropZone } from '@emerald-dao/component-library';
 	import validationSuite from './validation';
 	import { applyAction, enhance } from '$app/forms';
@@ -9,8 +8,6 @@
 
 	export let data;
 	export let form;
-
-	let activeDao = data.activeDao as DAOProject;
 
 	let changesSubmmited = false;
 	let submitionOnCourse = false;
@@ -35,13 +32,13 @@
 		submitionOnCourse = false;
 		changesSubmmited = true;
 
-		formData.website = (form?.website as string) ?? activeDao.generalInfo.website;
-		formData.twitter = (form?.twitter as string) ?? activeDao.generalInfo.twitter;
-		formData.discord = (form?.discord as string) ?? activeDao.generalInfo.discord;
-		formData.name = (form?.name as string) ?? activeDao.generalInfo.name;
-		formData.description = (form?.description as string) ?? activeDao.generalInfo.description;
+		formData.website = (form?.website as string) ?? data.activeDao.generalInfo.website;
+		formData.twitter = (form?.twitter as string) ?? data.activeDao.generalInfo.twitter;
+		formData.discord = (form?.discord as string) ?? data.activeDao.generalInfo.discord;
+		formData.name = (form?.name as string) ?? data.activeDao.generalInfo.name;
+		formData.description = (form?.description as string) ?? data.activeDao.generalInfo.description;
 		formData.long_description =
-			(form?.long_description as string) ?? activeDao.generalInfo.long_description;
+			(form?.long_description as string) ?? data.activeDao.generalInfo.long_description;
 	};
 
 	const handleChange = (input: Event) => {
@@ -56,25 +53,25 @@
 	};
 
 	const populateFormData = () => {
-		formData.website = activeDao.generalInfo.website ? activeDao.generalInfo.website : '';
-		formData.twitter = activeDao.generalInfo.twitter ? activeDao.generalInfo.twitter : '';
-		formData.name = activeDao.generalInfo.name ? activeDao.generalInfo.name : '';
-		formData.discord = activeDao.generalInfo.discord ? activeDao.generalInfo.discord : '';
-		formData.description = activeDao.generalInfo.description;
-		formData.long_description = activeDao.generalInfo.long_description
-			? activeDao.generalInfo.long_description
+		formData.website = data.activeDao.generalInfo.website ? data.activeDao.generalInfo.website : '';
+		formData.twitter = data.activeDao.generalInfo.twitter ? data.activeDao.generalInfo.twitter : '';
+		formData.name = data.activeDao.generalInfo.name ? data.activeDao.generalInfo.name : '';
+		formData.discord = data.activeDao.generalInfo.discord ? data.activeDao.generalInfo.discord : '';
+		formData.description = data.activeDao.generalInfo.description;
+		formData.long_description = data.activeDao.generalInfo.long_description
+			? data.activeDao.generalInfo.long_description
 			: '';
 	};
 
 	const checkDataChanges = () => {
-		if (activeDao) {
+		if (data.activeDao) {
 			return (
-				formData.website !== activeDao.generalInfo.website ||
-				formData.twitter !== activeDao.generalInfo.twitter ||
-				formData.discord !== activeDao.generalInfo.discord ||
-				formData.name !== activeDao.generalInfo.name ||
-				formData.description !== activeDao.generalInfo.description ||
-				formData.long_description !== activeDao.generalInfo.long_description ||
+				formData.website !== data.activeDao.generalInfo.website ||
+				formData.twitter !== data.activeDao.generalInfo.twitter ||
+				formData.discord !== data.activeDao.generalInfo.discord ||
+				formData.name !== data.activeDao.generalInfo.name ||
+				formData.description !== data.activeDao.generalInfo.description ||
+				formData.long_description !== data.activeDao.generalInfo.long_description ||
 				formData.logo.length > 0 ||
 				formData.bannerImage.length > 0
 			);
@@ -90,9 +87,9 @@
 
 	let res = validationSuite.get();
 
-	$: activeDao && populateFormData();
-	$: activeDao && formData && (formHasChanges = checkDataChanges());
-	$: activeDao && resetValidation();
+	$: data.activeDao && populateFormData();
+	$: data.activeDao && formData && (formHasChanges = checkDataChanges());
+	$: data.activeDao && resetValidation();
 </script>
 
 <AdminPage.Root>
@@ -117,7 +114,12 @@
 			autocomplete="off"
 		>
 			<div>
-				<input type="hidden" name="project_id" hidden value={activeDao.generalInfo.project_id} />
+				<input
+					type="hidden"
+					name="project_id"
+					hidden
+					value={data.activeDao.generalInfo.project_id}
+				/>
 				<InputWrapper
 					name="name"
 					label="Name"

--- a/frontend/src/routes/admin/[projectId]/lock/+page.svelte
+++ b/frontend/src/routes/admin/[projectId]/lock/+page.svelte
@@ -1,21 +1,18 @@
 <script type="ts">
 	import LockTokensForm from './_components/LockTokensForm.svelte';
-	import type { DAOProject } from '$lib/types/dao-project/dao-project.interface';
 	import * as DistributeTokens from '$lib/features/distribute-tokens/components';
 	import * as AdminPage from '../_components/admin-page';
 	import { onMount } from 'svelte';
 
 	export let data;
 
-	let activeDao = data.activeDao as DAOProject;
-
 	let activeCurrency: string;
 
 	onMount(() => {
-		activeCurrency = Object.keys(activeDao.onChainData.treasuryBalances)[0];
+		activeCurrency = Object.keys(data.activeDao.onChainData.treasuryBalances)[0];
 	});
 
-	$: availableBalance = Number(activeDao.onChainData.treasuryBalances[activeCurrency]);
+	$: availableBalance = Number(data.activeDao.onChainData.treasuryBalances[activeCurrency]);
 </script>
 
 <AdminPage.Root>
@@ -28,13 +25,13 @@
 				</AdminPage.Description>
 			</AdminPage.Header>
 			<DistributeTokens.Tabs>
-				{#each Object.entries(activeDao.onChainData.treasuryBalances) as [currency] (currency)}
+				{#each Object.entries(data.activeDao.onChainData.treasuryBalances) as [currency] (currency)}
 					<DistributeTokens.Tab {currency} bind:activeCurrency />
 				{/each}
 			</DistributeTokens.Tabs>
 			<DistributeTokens.AvailableBalance {availableBalance} currency={activeCurrency} />
 			{#if availableBalance && availableBalance > 0}
-				<LockTokensForm {activeCurrency} {availableBalance} activeDaoData={activeDao} />
+				<LockTokensForm {activeCurrency} {availableBalance} activeDaoData={data.activeDao} />
 			{:else}
 				<DistributeTokens.NoTokensMessage>
 					{`No ${activeCurrency} tokens available to lock.`}

--- a/frontend/src/routes/admin/[projectId]/lock/+page.svelte
+++ b/frontend/src/routes/admin/[projectId]/lock/+page.svelte
@@ -1,26 +1,21 @@
 <script type="ts">
 	import LockTokensForm from './_components/LockTokensForm.svelte';
-	import type { Writable } from 'svelte/store';
-	import { getContext, onMount } from 'svelte';
-	import type { DAOProject, DaoDatabaseData } from '$lib/types/dao-project/dao-project.interface';
+	import type { DAOProject } from '$lib/types/dao-project/dao-project.interface';
 	import * as DistributeTokens from '$lib/features/distribute-tokens/components';
 	import * as AdminPage from '../_components/admin-page';
+	import { onMount } from 'svelte';
 
-	const adminData: {
-		activeDao: Writable<DAOProject>;
-		otherDaos: DaoDatabaseData[];
-	} = getContext('admin-data');
+	export let data;
 
-	const activeDaoStore = adminData.activeDao;
-	$: activeDaoData = $activeDaoStore;
+	let activeDao = data.activeDao as DAOProject;
 
 	let activeCurrency: string;
 
 	onMount(() => {
-		activeCurrency = Object.keys(activeDaoData.onChainData.treasuryBalances)[0];
+		activeCurrency = Object.keys(activeDao.onChainData.treasuryBalances)[0];
 	});
 
-	$: availableBalance = Number(activeDaoData.onChainData.treasuryBalances[activeCurrency]);
+	$: availableBalance = Number(activeDao.onChainData.treasuryBalances[activeCurrency]);
 </script>
 
 <AdminPage.Root>
@@ -33,13 +28,13 @@
 				</AdminPage.Description>
 			</AdminPage.Header>
 			<DistributeTokens.Tabs>
-				{#each Object.entries(activeDaoData.onChainData.treasuryBalances) as [currency] (currency)}
+				{#each Object.entries(activeDao.onChainData.treasuryBalances) as [currency] (currency)}
 					<DistributeTokens.Tab {currency} bind:activeCurrency />
 				{/each}
 			</DistributeTokens.Tabs>
 			<DistributeTokens.AvailableBalance {availableBalance} currency={activeCurrency} />
 			{#if availableBalance && availableBalance > 0}
-				<LockTokensForm {activeCurrency} {availableBalance} {activeDaoData} />
+				<LockTokensForm {activeCurrency} {availableBalance} activeDaoData={activeDao} />
 			{:else}
 				<DistributeTokens.NoTokensMessage>
 					{`No ${activeCurrency} tokens available to lock.`}

--- a/frontend/src/routes/admin/[projectId]/mint/+page.svelte
+++ b/frontend/src/routes/admin/[projectId]/mint/+page.svelte
@@ -1,5 +1,4 @@
 <script type="ts">
-	import type { DAOProject } from '$lib/types/dao-project/dao-project.interface';
 	import * as DistributeTokens from '$lib/features/distribute-tokens/components';
 	import type { Distribution } from '$lib/types/dao-project/funding-rounds/distribution.interface';
 	import FungibleTokensDistributionForm from '../withdraw/_components/FungibleTokensDistributionForm.svelte';
@@ -8,10 +7,8 @@
 
 	export let data;
 
-	let activeDao = data.activeDao as DAOProject;
-
-	$: availableBalance = activeDao.onChainData.maxSupply
-		? Number(activeDao.onChainData.maxSupply) - Number(activeDao.onChainData.totalSupply)
+	$: availableBalance = data.activeDao.onChainData.maxSupply
+		? Number(data.activeDao.onChainData.maxSupply) - Number(data.activeDao.onChainData.totalSupply)
 		: ('infinite' as const);
 
 	let formDist: Distribution = {
@@ -32,7 +29,7 @@
 	};
 
 	const handleCreateMintAction = async () => {
-		const actionResult = await mintTokens(activeDao, distStaging);
+		const actionResult = await mintTokens(data.activeDao, distStaging);
 
 		if (actionResult.state === 'success') {
 			resetDistribution();
@@ -41,37 +38,40 @@
 </script>
 
 <AdminPage.Root>
-	{#if activeDao.generalInfo.token_symbol}
+	{#if data.activeDao.generalInfo.token_symbol}
 		<AdminPage.Container>
 			<AdminPage.Content>
 				<AdminPage.Header>
 					<AdminPage.Title>Mint Tokens</AdminPage.Title>
 					<AdminPage.Description>
-						{`Mint $${activeDao.generalInfo.token_symbol} tokens to external wallets.`}
+						{`Mint $${data.activeDao.generalInfo.token_symbol} tokens to external wallets.`}
 					</AdminPage.Description>
 				</AdminPage.Header>
 				<DistributeTokens.AvailableBalance
 					{availableBalance}
-					currency={activeDao.generalInfo.token_symbol}
+					currency={data.activeDao.generalInfo.token_symbol}
 				/>
 				{#if (availableBalance && Number(availableBalance) > 0) || availableBalance === 'infinite'}
 					<FungibleTokensDistributionForm
 						{formDist}
 						{csvDist}
-						activeCurrency={activeDao.generalInfo.token_symbol}
+						activeCurrency={data.activeDao.generalInfo.token_symbol}
 						{availableBalance}
-						projectOwner={activeDao.generalInfo.owner}
-						projectId={activeDao.generalInfo.project_id}
+						projectOwner={data.activeDao.generalInfo.owner}
+						projectId={data.activeDao.generalInfo.project_id}
 						bind:distStaging
 					/>
 				{:else}
 					<DistributeTokens.NoTokensMessage>
-						{`No ${activeDao.generalInfo.token_symbol} tokens available to mint.`}
+						{`No ${data.activeDao.generalInfo.token_symbol} tokens available to mint.`}
 					</DistributeTokens.NoTokensMessage>
 				{/if}
 			</AdminPage.Content>
 			<AdminPage.Content>
-				<DistributeTokens.Staging bind:distStaging tokenName={activeDao.generalInfo.token_symbol} />
+				<DistributeTokens.Staging
+					bind:distStaging
+					tokenName={data.activeDao.generalInfo.token_symbol}
+				/>
 				<DistributeTokens.Button
 					on:click={handleCreateMintAction}
 					disabled={distStaging.length === 0}>Create Mint Action</DistributeTokens.Button

--- a/frontend/src/routes/admin/[projectId]/multisig/+page.svelte
+++ b/frontend/src/routes/admin/[projectId]/multisig/+page.svelte
@@ -1,5 +1,4 @@
 <script type="ts">
-	import type { DAOProject } from '$lib/types/dao-project/dao-project.interface';
 	import { onMount } from 'svelte';
 	import { Button } from '@emerald-dao/component-library';
 	import MultisigManager from '$lib/features/multisig-manager/components/MultisigManager.svelte';
@@ -7,8 +6,6 @@
 	import * as AdminPage from '../_components/admin-page';
 
 	export let data;
-
-	let activeDao = data.activeDao as DAOProject;
 
 	let allWalletsValid: boolean = false;
 	let thresholdValid: boolean = true;
@@ -21,8 +18,8 @@
 	}[] = [];
 
 	const reloadData = () => {
-		existingAddresses = activeDao.onChainData.signers;
-		threshold = Number(activeDao.onChainData.threshold);
+		existingAddresses = data.activeDao.onChainData.signers;
+		threshold = Number(data.activeDao.onChainData.threshold);
 		newAddresses = [];
 	};
 
@@ -30,7 +27,7 @@
 		reloadData();
 	});
 
-	$: activeDao && reloadData();
+	$: data.activeDao && reloadData();
 	$: allAddresses = existingAddresses.concat(newAddresses.map((address) => address.address));
 </script>
 
@@ -47,19 +44,19 @@
 				bind:allWalletsValid
 				bind:thresholdValid
 				bind:threshold
-				owner={activeDao.generalInfo.owner}
-				projectId={activeDao.generalInfo.project_id}
+				owner={data.activeDao.generalInfo.owner}
+				projectId={data.activeDao.generalInfo.project_id}
 			/>
 			<Button
 				state={allWalletsValid &&
 				thresholdValid &&
-				(Number(activeDao.onChainData.threshold) !== threshold || newAddresses.length > 0)
+				(Number(data.activeDao.onChainData.threshold) !== threshold || newAddresses.length > 0)
 					? 'active'
 					: 'disabled'}
 				on:click={() =>
 					updateMultisigExecution(
-						activeDao.generalInfo.owner,
-						activeDao.generalInfo.project_id,
+						data.activeDao.generalInfo.owner,
+						data.activeDao.generalInfo.project_id,
 						allAddresses,
 						threshold
 					)}

--- a/frontend/src/routes/admin/[projectId]/multisig/+page.svelte
+++ b/frontend/src/routes/admin/[projectId]/multisig/+page.svelte
@@ -1,19 +1,14 @@
 <script type="ts">
-	import type { DAOProject, DaoDatabaseData } from '$lib/types/dao-project/dao-project.interface';
-	import { getContext, onMount } from 'svelte';
-	import type { Writable } from 'svelte/store';
+	import type { DAOProject } from '$lib/types/dao-project/dao-project.interface';
+	import { onMount } from 'svelte';
 	import { Button } from '@emerald-dao/component-library';
 	import MultisigManager from '$lib/features/multisig-manager/components/MultisigManager.svelte';
 	import { updateMultisigExecution } from '$flow/actions';
 	import * as AdminPage from '../_components/admin-page';
 
-	const adminData: {
-		activeDao: Writable<DAOProject>;
-		otherDaos: DaoDatabaseData[];
-	} = getContext('admin-data');
+	export let data;
 
-	const activeDaoStore = adminData.activeDao;
-	$: activeDaoData = $activeDaoStore;
+	let activeDao = data.activeDao as DAOProject;
 
 	let allWalletsValid: boolean = false;
 	let thresholdValid: boolean = true;
@@ -26,8 +21,8 @@
 	}[] = [];
 
 	const reloadData = () => {
-		existingAddresses = activeDaoData.onChainData.signers;
-		threshold = Number(activeDaoData.onChainData.threshold);
+		existingAddresses = activeDao.onChainData.signers;
+		threshold = Number(activeDao.onChainData.threshold);
 		newAddresses = [];
 	};
 
@@ -35,7 +30,7 @@
 		reloadData();
 	});
 
-	$: activeDaoData && reloadData();
+	$: activeDao && reloadData();
 	$: allAddresses = existingAddresses.concat(newAddresses.map((address) => address.address));
 </script>
 
@@ -52,19 +47,19 @@
 				bind:allWalletsValid
 				bind:thresholdValid
 				bind:threshold
-				owner={activeDaoData.generalInfo.owner}
-				projectId={activeDaoData.generalInfo.project_id}
+				owner={activeDao.generalInfo.owner}
+				projectId={activeDao.generalInfo.project_id}
 			/>
 			<Button
 				state={allWalletsValid &&
 				thresholdValid &&
-				(Number(activeDaoData.onChainData.threshold) !== threshold || newAddresses.length > 0)
+				(Number(activeDao.onChainData.threshold) !== threshold || newAddresses.length > 0)
 					? 'active'
 					: 'disabled'}
 				on:click={() =>
 					updateMultisigExecution(
-						activeDaoData.generalInfo.owner,
-						activeDaoData.generalInfo.project_id,
+						activeDao.generalInfo.owner,
+						activeDao.generalInfo.project_id,
 						allAddresses,
 						threshold
 					)}

--- a/frontend/src/routes/admin/[projectId]/nft-collections/+page.svelte
+++ b/frontend/src/routes/admin/[projectId]/nft-collections/+page.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import SearchBar from '$lib/components/search-bar/SearchBar.svelte';
 	import NFTCollectionSelectedCard from '$lib/features/nft-treasury/components/nft-collections-list/NFTCollectionSelectedCard.svelte';
-	import type { DAOProject } from '$lib/types/dao-project/dao-project.interface.js';
 	import { Button } from '@emerald-dao/component-library';
 	import { addAllowedNFTCollections } from './_actions/addAllowedNFTCollections.js';
 	import NFTCollectionSelectCard from '$lib/features/nft-treasury/components/nft-collections-list/NFTCollectionSelectCard.svelte';
@@ -10,7 +9,15 @@
 
 	export let data;
 
-	let activeDao = data.activeDao as DAOProject;
+	const handleAddCollection = (collection) => {
+		addAllowedNFTCollections(
+			selectedCollections,
+			data.activeDao.generalInfo.owner,
+			data.activeDao.generalInfo.project_id
+		);
+
+		selectedCollections = [];
+	};
 
 	let collectionsList = Object.values(data.projectNFTs);
 	let filteredCollections = collectionsList;
@@ -19,7 +26,9 @@
 	let pageEnd: number;
 
 	$: currentPageCollections = filteredCollections
-		.sort((a, b) => (activeDao.onChainData.allowedNFTCollections.includes(a.identifier) ? -1 : 1))
+		.sort((a, b) =>
+			data.activeDao.onChainData.allowedNFTCollections.includes(a.identifier) ? -1 : 1
+		)
 		.slice(pageStart, pageEnd);
 
 	let selectedCollections: string[] = [];
@@ -45,11 +54,11 @@
 					{#if filteredCollections.length > 0}
 						<div class="collections-wrapper">
 							{#each currentPageCollections as collection (collection.identifier)}
-								{#if activeDao.onChainData.allowedNFTCollections.includes(collection.identifier)}
+								{#if data.activeDao.onChainData.allowedNFTCollections.includes(collection.identifier)}
 									<NFTCollectionSelectedCard
 										nftCollection={collection}
 										bind:selectedCollections
-										daoData={activeDao}
+										daoData={data.activeDao}
 									/>
 								{:else}
 									<NFTCollectionSelectCard nftCollection={collection} bind:selectedCollections />
@@ -70,12 +79,7 @@
 				</div>
 				<Button
 					state={selectedCollections.length === 0 ? 'disabled' : 'active'}
-					on:click={() =>
-						addAllowedNFTCollections(
-							selectedCollections,
-							activeDao.generalInfo.owner,
-							activeDao.generalInfo.project_id
-						)}
+					on:click={handleAddCollection}
 					>{`Add ${selectedCollections.length === 0 ? 'selected' : selectedCollections.length} ${
 						selectedCollections.length === 1 ? 'collection' : 'collections'
 					}`}</Button

--- a/frontend/src/routes/admin/[projectId]/nft-collections/+page.svelte
+++ b/frontend/src/routes/admin/[projectId]/nft-collections/+page.svelte
@@ -1,13 +1,8 @@
 <script lang="ts">
 	import SearchBar from '$lib/components/search-bar/SearchBar.svelte';
 	import NFTCollectionSelectedCard from '$lib/features/nft-treasury/components/nft-collections-list/NFTCollectionSelectedCard.svelte';
-	import type {
-		DAOProject,
-		DaoDatabaseData
-	} from '$lib/types/dao-project/dao-project.interface.js';
+	import type { DAOProject } from '$lib/types/dao-project/dao-project.interface.js';
 	import { Button } from '@emerald-dao/component-library';
-	import { getContext } from 'svelte';
-	import type { Writable } from 'svelte/store';
 	import { addAllowedNFTCollections } from './_actions/addAllowedNFTCollections.js';
 	import NFTCollectionSelectCard from '$lib/features/nft-treasury/components/nft-collections-list/NFTCollectionSelectCard.svelte';
 	import Pagination from '$lib/components/atoms/Pagination.svelte';
@@ -15,13 +10,7 @@
 
 	export let data;
 
-	const adminData: {
-		activeDao: Writable<DAOProject>;
-		otherDaos: DaoDatabaseData[];
-	} = getContext('admin-data');
-
-	const activeDaoStore = adminData.activeDao;
-	$: activeDaoData = $activeDaoStore;
+	let activeDao = data.activeDao as DAOProject;
 
 	let collectionsList = Object.values(data.projectNFTs);
 	let filteredCollections = collectionsList;
@@ -30,9 +19,7 @@
 	let pageEnd: number;
 
 	$: currentPageCollections = filteredCollections
-		.sort((a, b) =>
-			activeDaoData.onChainData.allowedNFTCollections.includes(a.identifier) ? -1 : 1
-		)
+		.sort((a, b) => (activeDao.onChainData.allowedNFTCollections.includes(a.identifier) ? -1 : 1))
 		.slice(pageStart, pageEnd);
 
 	let selectedCollections: string[] = [];
@@ -58,8 +45,12 @@
 					{#if filteredCollections.length > 0}
 						<div class="collections-wrapper">
 							{#each currentPageCollections as collection (collection.identifier)}
-								{#if activeDaoData.onChainData.allowedNFTCollections.includes(collection.identifier)}
-									<NFTCollectionSelectedCard nftCollection={collection} bind:selectedCollections />
+								{#if activeDao.onChainData.allowedNFTCollections.includes(collection.identifier)}
+									<NFTCollectionSelectedCard
+										nftCollection={collection}
+										bind:selectedCollections
+										daoData={activeDao}
+									/>
 								{:else}
 									<NFTCollectionSelectCard nftCollection={collection} bind:selectedCollections />
 								{/if}
@@ -82,8 +73,8 @@
 					on:click={() =>
 						addAllowedNFTCollections(
 							selectedCollections,
-							activeDaoData.generalInfo.owner,
-							activeDaoData.generalInfo.project_id
+							activeDao.generalInfo.owner,
+							activeDao.generalInfo.project_id
 						)}
 					>{`Add ${selectedCollections.length === 0 ? 'selected' : selectedCollections.length} ${
 						selectedCollections.length === 1 ? 'collection' : 'collections'

--- a/frontend/src/routes/admin/[projectId]/nft-collections/+page.ts
+++ b/frontend/src/routes/admin/[projectId]/nft-collections/+page.ts
@@ -1,7 +1,9 @@
 import type { PageLoad } from './$types';
 import { getNFTCatalog } from '$flow/actions';
 
-export const load: PageLoad = async () => {
+export const load: PageLoad = async ({ depends }) => {
+	depends('app:project-nfts');
+
 	return {
 		projectNFTs: await getNFTCatalog()
 	};

--- a/frontend/src/routes/admin/[projectId]/nft-collections/_actions/addAllowedNFTCollections.ts
+++ b/frontend/src/routes/admin/[projectId]/nft-collections/_actions/addAllowedNFTCollections.ts
@@ -1,3 +1,4 @@
+import { invalidate } from '$app/navigation';
 import { addAllowedNFTCollectionsExecution } from '$flow/actions';
 
 export const addAllowedNFTCollections = async (
@@ -5,5 +6,7 @@ export const addAllowedNFTCollections = async (
 	owner: string,
 	project_id: string
 ) => {
-	return await addAllowedNFTCollectionsExecution(owner, project_id, selectedNFTs);
+	return await addAllowedNFTCollectionsExecution(owner, project_id, selectedNFTs).then(() => {
+		invalidate('app:project-nfts');
+	});
 };

--- a/frontend/src/routes/admin/[projectId]/nft-collections/_actions/removeAllowedNFTCollections.ts
+++ b/frontend/src/routes/admin/[projectId]/nft-collections/_actions/removeAllowedNFTCollections.ts
@@ -1,3 +1,4 @@
+import { invalidate } from '$app/navigation';
 import { removeAllowedNFTCollectionsExecution } from '$flow/actions';
 
 export const removeAllowedNFTCollections = async (
@@ -5,5 +6,7 @@ export const removeAllowedNFTCollections = async (
 	owner: string,
 	project_id: string
 ) => {
-	return await removeAllowedNFTCollectionsExecution(owner, project_id, removedNFT);
+	return await removeAllowedNFTCollectionsExecution(owner, project_id, removedNFT).then(() => {
+		invalidate('app:project-nfts');
+	});
 };

--- a/frontend/src/routes/admin/[projectId]/overflow/+page.svelte
+++ b/frontend/src/routes/admin/[projectId]/overflow/+page.svelte
@@ -1,30 +1,24 @@
 <script lang="ts">
-	import { getContext } from 'svelte';
-	import type { Writable } from 'svelte/store';
 	import { Button, Currency } from '@emerald-dao/component-library';
 	import CurrencyInput from '$lib/components/atoms/CurrencyInput.svelte';
-	import type { DAOProject, DaoDatabaseData } from '$lib/types/dao-project/dao-project.interface';
+	import type { DAOProject } from '$lib/types/dao-project/dao-project.interface';
 	import CheckElement from './_components/CheckElement.svelte';
 	import { transferOverflowSuite } from './_validations/validation';
 	import { transferOverflowExecution } from '$flow/actions';
 	import * as AdminPage from '../_components/admin-page';
 
-	const adminData: {
-		activeDao: Writable<DAOProject>;
-		otherDaos: DaoDatabaseData[];
-	} = getContext('admin-data');
+	export let data;
 
-	const activeDaoStore = adminData.activeDao;
-	$: activeDaoData = $activeDaoStore;
+	let activeDao = data.activeDao as DAOProject;
 
-	$: activeRound = activeDaoData.onChainData.currentFundingCycle;
+	$: activeRound = activeDao.onChainData.currentFundingCycle;
 
 	// Transfer overflow
 	let transferAmount: number = 0;
 	const onTransferOverflowTokens = async () => {
 		await transferOverflowExecution(
-			activeDaoData.generalInfo.owner,
-			activeDaoData.generalInfo.project_id,
+			activeDao.generalInfo.owner,
+			activeDao.generalInfo.project_id,
 			transferAmount.toString()
 		);
 	};
@@ -35,7 +29,7 @@
 		res = transferOverflowSuite(
 			transferAmount,
 			amountToGoal,
-			Number(activeDaoData.onChainData.overflowBalance)
+			Number(activeDao.onChainData.overflowBalance)
 		);
 	};
 
@@ -51,7 +45,7 @@
 
 	$: isEligibleForTransfer =
 		activeRound !== null &&
-		Number(activeDaoData.onChainData.overflowBalance) > 0 &&
+		Number(activeDao.onChainData.overflowBalance) > 0 &&
 		(amountToGoal > 0 || activeRoundGoal == 'infinite');
 </script>
 
@@ -68,8 +62,8 @@
 			<div class="card column-1">
 				<span> Available overflow </span>
 				<Currency
-					amount={Number(activeDaoData.onChainData.overflowBalance)}
-					currency={activeDaoData.onChainData.paymentCurrency}
+					amount={Number(activeDao.onChainData.overflowBalance)}
+					currency={activeDao.onChainData.paymentCurrency}
 					fontSize="1.5rem"
 					color="heading"
 				/>
@@ -92,7 +86,7 @@
 						/>
 					{/if}
 					<CheckElement
-						check={Number(activeDaoData.onChainData.overflowBalance) > 0}
+						check={Number(activeDao.onChainData.overflowBalance) > 0}
 						text="The DAO has overflow tokens"
 					/>
 				</div>
@@ -104,7 +98,7 @@
 					<CurrencyInput
 						name="transferOverflowAmount"
 						autofocus={true}
-						currency={activeDaoData.onChainData.paymentCurrency}
+						currency={activeDao.onChainData.paymentCurrency}
 						isValid={res.isValid()}
 						errors={res.getErrors('transferOverflowAmount')}
 						bind:value={transferAmount}

--- a/frontend/src/routes/admin/[projectId]/overflow/+page.svelte
+++ b/frontend/src/routes/admin/[projectId]/overflow/+page.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import { Button, Currency } from '@emerald-dao/component-library';
 	import CurrencyInput from '$lib/components/atoms/CurrencyInput.svelte';
-	import type { DAOProject } from '$lib/types/dao-project/dao-project.interface';
 	import CheckElement from './_components/CheckElement.svelte';
 	import { transferOverflowSuite } from './_validations/validation';
 	import { transferOverflowExecution } from '$flow/actions';
@@ -9,16 +8,14 @@
 
 	export let data;
 
-	let activeDao = data.activeDao as DAOProject;
-
-	$: activeRound = activeDao.onChainData.currentFundingCycle;
+	$: activeRound = data.activeDao.onChainData.currentFundingCycle;
 
 	// Transfer overflow
 	let transferAmount: number = 0;
 	const onTransferOverflowTokens = async () => {
 		await transferOverflowExecution(
-			activeDao.generalInfo.owner,
-			activeDao.generalInfo.project_id,
+			data.activeDao.generalInfo.owner,
+			data.activeDao.generalInfo.project_id,
 			transferAmount.toString()
 		);
 	};
@@ -29,7 +26,7 @@
 		res = transferOverflowSuite(
 			transferAmount,
 			amountToGoal,
-			Number(activeDao.onChainData.overflowBalance)
+			Number(data.activeDao.onChainData.overflowBalance)
 		);
 	};
 
@@ -45,7 +42,7 @@
 
 	$: isEligibleForTransfer =
 		activeRound !== null &&
-		Number(activeDao.onChainData.overflowBalance) > 0 &&
+		Number(data.activeDao.onChainData.overflowBalance) > 0 &&
 		(amountToGoal > 0 || activeRoundGoal == 'infinite');
 </script>
 
@@ -62,8 +59,8 @@
 			<div class="card column-1">
 				<span> Available overflow </span>
 				<Currency
-					amount={Number(activeDao.onChainData.overflowBalance)}
-					currency={activeDao.onChainData.paymentCurrency}
+					amount={Number(data.activeDao.onChainData.overflowBalance)}
+					currency={data.activeDao.onChainData.paymentCurrency}
 					fontSize="1.5rem"
 					color="heading"
 				/>
@@ -86,7 +83,7 @@
 						/>
 					{/if}
 					<CheckElement
-						check={Number(activeDao.onChainData.overflowBalance) > 0}
+						check={Number(data.activeDao.onChainData.overflowBalance) > 0}
 						text="The DAO has overflow tokens"
 					/>
 				</div>
@@ -98,7 +95,7 @@
 					<CurrencyInput
 						name="transferOverflowAmount"
 						autofocus={true}
-						currency={activeDao.onChainData.paymentCurrency}
+						currency={data.activeDao.onChainData.paymentCurrency}
 						isValid={res.isValid()}
 						errors={res.getErrors('transferOverflowAmount')}
 						bind:value={transferAmount}

--- a/frontend/src/routes/admin/[projectId]/rounds/+page.svelte
+++ b/frontend/src/routes/admin/[projectId]/rounds/+page.svelte
@@ -1,18 +1,12 @@
 <script type="ts">
 	import RoundsList from '$lib/components/dao-data-blocks/funding-rounds/list/RoundsList.svelte';
-	import type { DAOProject, DaoDatabaseData } from '$lib/types/dao-project/dao-project.interface';
-	import { getContext } from 'svelte';
-	import type { Writable } from 'svelte/store';
 	import RoundGeneratorModal from '$lib/features/round-generator/components/RoundGeneratorModal.svelte';
+	import type { DAOProject } from '$lib/types/dao-project/dao-project.interface';
 	import * as AdminPage from '../_components/admin-page';
 
-	const adminData: {
-		activeDao: Writable<DAOProject>;
-		otherDaos: DaoDatabaseData[];
-	} = getContext('admin-data');
+	export let data;
 
-	const activeDaoStore = adminData.activeDao;
-	$: activeDaoData = $activeDaoStore;
+	let activeDao = data.activeDao as DAOProject;
 </script>
 
 <AdminPage.Root>
@@ -21,12 +15,12 @@
 	</AdminPage.Header>
 	<AdminPage.Container grid={false}>
 		<AdminPage.Content>
-			{#if activeDaoData.onChainData.fundingCycles.length < 1}
+			{#if activeDao.onChainData.fundingCycles.length < 1}
 				<AdminPage.EmptyMessage>This project has no funding rounds yet</AdminPage.EmptyMessage>
 			{:else}
-				<RoundsList daoData={activeDaoData} />
+				<RoundsList daoData={activeDao} />
 			{/if}
-			<RoundGeneratorModal daoData={activeDaoData} />
+			<RoundGeneratorModal daoData={activeDao} />
 		</AdminPage.Content>
 	</AdminPage.Container>
 </AdminPage.Root>

--- a/frontend/src/routes/admin/[projectId]/rounds/+page.svelte
+++ b/frontend/src/routes/admin/[projectId]/rounds/+page.svelte
@@ -1,12 +1,9 @@
 <script type="ts">
 	import RoundsList from '$lib/components/dao-data-blocks/funding-rounds/list/RoundsList.svelte';
 	import RoundGeneratorModal from '$lib/features/round-generator/components/RoundGeneratorModal.svelte';
-	import type { DAOProject } from '$lib/types/dao-project/dao-project.interface';
 	import * as AdminPage from '../_components/admin-page';
 
 	export let data;
-
-	let activeDao = data.activeDao as DAOProject;
 </script>
 
 <AdminPage.Root>
@@ -15,12 +12,12 @@
 	</AdminPage.Header>
 	<AdminPage.Container grid={false}>
 		<AdminPage.Content>
-			{#if activeDao.onChainData.fundingCycles.length < 1}
+			{#if data.activeDao.onChainData.fundingCycles.length < 1}
 				<AdminPage.EmptyMessage>This project has no funding rounds yet</AdminPage.EmptyMessage>
 			{:else}
-				<RoundsList daoData={activeDao} />
+				<RoundsList daoData={data.activeDao} />
 			{/if}
-			<RoundGeneratorModal daoData={activeDao} />
+			<RoundGeneratorModal daoData={data.activeDao} />
 		</AdminPage.Content>
 	</AdminPage.Container>
 </AdminPage.Root>

--- a/frontend/src/routes/admin/[projectId]/staking/+page.svelte
+++ b/frontend/src/routes/admin/[projectId]/staking/+page.svelte
@@ -1,15 +1,12 @@
 <script type="ts">
 	import { fly } from 'svelte/transition';
-	import type { DAOProject } from '$lib/types/dao-project/dao-project.interface';
 	import Stake from './components/Stake.svelte';
 
 	export let data;
-
-	let activeDao = data.activeDao as DAOProject;
 </script>
 
 <div in:fly={{ x: 10, duration: 400 }}>
-	<Stake daoData={activeDao} />
+	<Stake daoData={data.activeDao} />
 </div>
 
 <style lang="scss">

--- a/frontend/src/routes/admin/[projectId]/staking/+page.svelte
+++ b/frontend/src/routes/admin/[projectId]/staking/+page.svelte
@@ -1,21 +1,15 @@
 <script type="ts">
 	import { fly } from 'svelte/transition';
-	import type { Writable } from 'svelte/store';
-	import { getContext } from 'svelte';
-	import type { DAOProject, DaoDatabaseData } from '$lib/types/dao-project/dao-project.interface';
+	import type { DAOProject } from '$lib/types/dao-project/dao-project.interface';
 	import Stake from './components/Stake.svelte';
 
-	const adminData: {
-		activeDao: Writable<DAOProject>;
-		otherDaos: DaoDatabaseData[];
-	} = getContext('admin-data');
+	export let data;
 
-	const activeDaoStore = adminData.activeDao;
-	$: activeDaoData = $activeDaoStore;
+	let activeDao = data.activeDao as DAOProject;
 </script>
 
 <div in:fly={{ x: 10, duration: 400 }}>
-	<Stake daoData={activeDaoData} />
+	<Stake daoData={activeDao} />
 </div>
 
 <style lang="scss">

--- a/frontend/src/routes/admin/[projectId]/staking/components/Stake.svelte
+++ b/frontend/src/routes/admin/[projectId]/staking/components/Stake.svelte
@@ -1,8 +1,6 @@
 <script type="ts">
-	import { Button, Currency, InputWrapper } from '@emerald-dao/component-library';
-	import { paymentActiveStep } from '$lib/features/payments/stores/PaymentSteps';
+	import { Button, Currency } from '@emerald-dao/component-library';
 	import { fade } from 'svelte/transition';
-	import { paymentData } from '$lib/features/payments/stores/PaymentData';
 	import CurrencySelect from '$components/atoms/CurrencySelect.svelte';
 	import { ECurrencies } from '$lib/types/common/enums';
 	import CurrencyInput from '$components/atoms/CurrencyInput.svelte';
@@ -16,7 +14,7 @@
 	let amountOut = 0;
 	let timeout;
 	let price = 0;
-	console.log(daoData.onChainData.treasuryBalances);
+
 	$: availableBalance = Number(daoData.onChainData.treasuryBalances[currencyIn]);
 
 	let isValid = true;
@@ -48,9 +46,19 @@
 	async function runTransaction() {
 		if (currencyIn === ECurrencies.FLOW) {
 			// stake with 1% slippage
-			await stakeFlowExecution(daoData.generalInfo.project_id, daoData.generalInfo.owner, amountIn, amountOut * 0.99);
+			await stakeFlowExecution(
+				daoData.generalInfo.project_id,
+				daoData.generalInfo.owner,
+				amountIn,
+				amountOut * 0.99
+			);
 		} else if (currencyIn === ECurrencies.stFlow) {
-			await unstakeFlowExecution(daoData.generalInfo.project_id, daoData.generalInfo.owner, amountIn, amountOut * 0.99);
+			await unstakeFlowExecution(
+				daoData.generalInfo.project_id,
+				daoData.generalInfo.owner,
+				amountIn,
+				amountOut * 0.99
+			);
 		}
 	}
 </script>

--- a/frontend/src/routes/admin/[projectId]/voting/+page.server.ts
+++ b/frontend/src/routes/admin/[projectId]/voting/+page.server.ts
@@ -5,6 +5,7 @@ import { env as PublicEnv } from '$env/dynamic/public';
 import type { CurrentUserObject } from '@onflow/fcl';
 import { verifyAccountOwnership } from '$flow/utils.js';
 import { fail } from '@sveltejs/kit';
+import { invalidate } from '$app/navigation';
 
 const supabase = createClient<Database>(
 	PublicEnv.PUBLIC_SUPABASE_URL,

--- a/frontend/src/routes/admin/[projectId]/voting/+page.svelte
+++ b/frontend/src/routes/admin/[projectId]/voting/+page.svelte
@@ -1,12 +1,9 @@
 <script type="ts">
 	import VotingGeneratorModal from './_components/VotingGeneratorModal.svelte';
-	import type { DAOProject } from '$lib/types/dao-project/dao-project.interface';
 	import * as AdminPage from '../_components/admin-page';
 	import VotingRoundsGrid from '$lib/features/voting-rounds/components/voting-round-card/VotingRoundsGrid.svelte';
 
 	export let data;
-
-	let activeDao = data.activeDao as DAOProject;
 </script>
 
 <AdminPage.Root>
@@ -19,11 +16,11 @@
 				<VotingRoundsGrid
 					votingRounds={data.votingRounds}
 					cardsPerPage={3}
-					daoSigners={activeDao.onChainData.signers}
+					daoSigners={data.activeDao.onChainData.signers}
 					showDeleteButton={true}
 				/>
 			</div>
-			<VotingGeneratorModal daoData={activeDao} />
+			<VotingGeneratorModal daoData={data.activeDao} />
 		</AdminPage.Content>
 	</AdminPage.Container>
 </AdminPage.Root>

--- a/frontend/src/routes/admin/[projectId]/voting/+page.svelte
+++ b/frontend/src/routes/admin/[projectId]/voting/+page.svelte
@@ -1,20 +1,12 @@
 <script type="ts">
 	import VotingGeneratorModal from './_components/VotingGeneratorModal.svelte';
-	import type { DAOProject, DaoDatabaseData } from '$lib/types/dao-project/dao-project.interface';
-	import { getContext } from 'svelte';
-	import type { Writable } from 'svelte/store';
+	import type { DAOProject } from '$lib/types/dao-project/dao-project.interface';
 	import * as AdminPage from '../_components/admin-page';
 	import VotingRoundsGrid from '$lib/features/voting-rounds/components/voting-round-card/VotingRoundsGrid.svelte';
 
 	export let data;
 
-	const adminData: {
-		activeDao: Writable<DAOProject>;
-		otherDaos: DaoDatabaseData[];
-	} = getContext('admin-data');
-
-	const activeDaoStore = adminData.activeDao;
-	$: activeDaoData = $activeDaoStore;
+	let activeDao = data.activeDao as DAOProject;
 </script>
 
 <AdminPage.Root>
@@ -27,11 +19,11 @@
 				<VotingRoundsGrid
 					votingRounds={data.votingRounds}
 					cardsPerPage={3}
-					daoSigners={activeDaoData.onChainData.signers}
+					daoSigners={activeDao.onChainData.signers}
 					showDeleteButton={true}
 				/>
 			</div>
-			<VotingGeneratorModal daoData={activeDaoData} />
+			<VotingGeneratorModal daoData={activeDao} />
 		</AdminPage.Content>
 	</AdminPage.Container>
 </AdminPage.Root>

--- a/frontend/src/routes/admin/[projectId]/voting/+page.ts
+++ b/frontend/src/routes/admin/[projectId]/voting/+page.ts
@@ -1,6 +1,8 @@
 import { fetchAllVotingRounds } from '$lib/utilities/api/supabase/fetchAllVotingRounds.js';
 
-export async function load({ params }) {
+export async function load({ params, depends }) {
+	depends('app:voting-rounds');
+
 	return {
 		votingRounds: await fetchAllVotingRounds(params.projectId)
 	};

--- a/frontend/src/routes/admin/[projectId]/voting/_actions/createVotingRound.ts
+++ b/frontend/src/routes/admin/[projectId]/voting/_actions/createVotingRound.ts
@@ -21,7 +21,7 @@ export const createVotingRound = async (): Promise<ActionExecutionResult> => {
 	const result = await postVotingRound(projectId, userObj, generatorData);
 
 	if (result === 'success') {
-		await invalidate((url) => url.pathname === `/admin/${projectId}/voting`);
+		await invalidate('app:voting-rounds');
 		resetVotingGeneratorStores();
 	}
 

--- a/frontend/src/routes/admin/[projectId]/withdraw/+page.svelte
+++ b/frontend/src/routes/admin/[projectId]/withdraw/+page.svelte
@@ -7,15 +7,12 @@
 	import { withdrawTokens } from '$lib/features/distribute-tokens/functions/withdrawTokens';
 	import type { ECurrencies } from '$lib/types/common/enums';
 	import FungibleTokensDistributionForm from './_components/FungibleTokensDistributionForm.svelte';
-	import type { DAOProject } from '$lib/types/dao-project/dao-project.interface';
 
 	export let data;
 
-	let activeDao = data.activeDao as DAOProject;
-
 	let activeCurrency: string;
 	onMount(() => {
-		activeCurrency = Object.keys(activeDao.onChainData.treasuryBalances)[0];
+		activeCurrency = Object.keys(data.activeDao.onChainData.treasuryBalances)[0];
 	});
 
 	let formDist: Distribution = {
@@ -26,7 +23,7 @@
 
 	let distStaging: Distribution[] = [];
 
-	$: availableBalance = Number(activeDao.onChainData.treasuryBalances[activeCurrency]);
+	$: availableBalance = Number(data.activeDao.onChainData.treasuryBalances[activeCurrency]);
 
 	const resetDistribution = () => {
 		formDist = {
@@ -42,7 +39,7 @@
 
 	const handleCreateWithdrawAction = async () => {
 		const actionResult = await withdrawTokens(
-			activeDao,
+			data.activeDao,
 			distStaging,
 			activeCurrency as ECurrencies
 		);
@@ -63,7 +60,7 @@
 				</AdminPage.Description>
 			</AdminPage.Header>
 			<DistributeTokens.Tabs>
-				{#each Object.entries(activeDao.onChainData.treasuryBalances) as [currency] (currency)}
+				{#each Object.entries(data.activeDao.onChainData.treasuryBalances) as [currency] (currency)}
 					<DistributeTokens.Tab {currency} bind:activeCurrency />
 				{/each}
 				<DistributeTokens.Tab currency="NFTs" bind:activeCurrency />
@@ -76,8 +73,8 @@
 						{csvDist}
 						{activeCurrency}
 						{availableBalance}
-						projectOwner={activeDao.generalInfo.owner}
-						projectId={activeDao.generalInfo.project_id}
+						projectOwner={data.activeDao.generalInfo.owner}
+						projectId={data.activeDao.generalInfo.project_id}
 						bind:distStaging
 					/>
 				{:else}
@@ -86,8 +83,8 @@
 					</DistributeTokens.NoTokensMessage>
 				{/if}
 			{:else if activeCurrency === 'NFTs'}
-				{#if activeDao.onChainData.allowedNFTCollections.length > 0}
-					<NFTDistributionForm {activeDao} />
+				{#if data.activeDao.onChainData.allowedNFTCollections.length > 0}
+					<NFTDistributionForm activeDao={data.activeDao} />
 				{:else}
 					<DistributeTokens.NoTokensMessage>
 						{`We didn't find any NFT on this treasury.`}

--- a/frontend/src/routes/admin/[projectId]/withdraw/+page.svelte
+++ b/frontend/src/routes/admin/[projectId]/withdraw/+page.svelte
@@ -1,27 +1,21 @@
 <script type="ts">
 	import NFTDistributionForm from './_components/NFTDistributionForm.svelte';
-	import type { Writable } from 'svelte/store';
-	import { getContext, onMount } from 'svelte';
-	import type { DAOProject, DaoDatabaseData } from '$lib/types/dao-project/dao-project.interface';
+	import { onMount } from 'svelte';
 	import * as DistributeTokens from '$lib/features/distribute-tokens/components';
 	import * as AdminPage from '../_components/admin-page';
 	import type { Distribution } from '$lib/types/dao-project/funding-rounds/distribution.interface';
 	import { withdrawTokens } from '$lib/features/distribute-tokens/functions/withdrawTokens';
 	import type { ECurrencies } from '$lib/types/common/enums';
 	import FungibleTokensDistributionForm from './_components/FungibleTokensDistributionForm.svelte';
+	import type { DAOProject } from '$lib/types/dao-project/dao-project.interface';
 
-	const adminData: {
-		activeDao: Writable<DAOProject>;
-		otherDaos: DaoDatabaseData[];
-	} = getContext('admin-data');
+	export let data;
 
-	const activeDaoStore = adminData.activeDao;
-	$: activeDaoData = $activeDaoStore;
+	let activeDao = data.activeDao as DAOProject;
 
 	let activeCurrency: string;
-
 	onMount(() => {
-		activeCurrency = Object.keys(activeDaoData.onChainData.treasuryBalances)[0];
+		activeCurrency = Object.keys(activeDao.onChainData.treasuryBalances)[0];
 	});
 
 	let formDist: Distribution = {
@@ -32,7 +26,7 @@
 
 	let distStaging: Distribution[] = [];
 
-	$: availableBalance = Number(activeDaoData.onChainData.treasuryBalances[activeCurrency]);
+	$: availableBalance = Number(activeDao.onChainData.treasuryBalances[activeCurrency]);
 
 	const resetDistribution = () => {
 		formDist = {
@@ -48,7 +42,7 @@
 
 	const handleCreateWithdrawAction = async () => {
 		const actionResult = await withdrawTokens(
-			activeDaoData,
+			activeDao,
 			distStaging,
 			activeCurrency as ECurrencies
 		);
@@ -69,7 +63,7 @@
 				</AdminPage.Description>
 			</AdminPage.Header>
 			<DistributeTokens.Tabs>
-				{#each Object.entries(activeDaoData.onChainData.treasuryBalances) as [currency] (currency)}
+				{#each Object.entries(activeDao.onChainData.treasuryBalances) as [currency] (currency)}
 					<DistributeTokens.Tab {currency} bind:activeCurrency />
 				{/each}
 				<DistributeTokens.Tab currency="NFTs" bind:activeCurrency />
@@ -82,8 +76,8 @@
 						{csvDist}
 						{activeCurrency}
 						{availableBalance}
-						projectOwner={activeDaoData.generalInfo.owner}
-						projectId={activeDaoData.generalInfo.project_id}
+						projectOwner={activeDao.generalInfo.owner}
+						projectId={activeDao.generalInfo.project_id}
 						bind:distStaging
 					/>
 				{:else}
@@ -92,8 +86,8 @@
 					</DistributeTokens.NoTokensMessage>
 				{/if}
 			{:else if activeCurrency === 'NFTs'}
-				{#if activeDaoData.onChainData.allowedNFTCollections.length > 0}
-					<NFTDistributionForm {activeDaoData} />
+				{#if activeDao.onChainData.allowedNFTCollections.length > 0}
+					<NFTDistributionForm {activeDao} />
 				{:else}
 					<DistributeTokens.NoTokensMessage>
 						{`We didn't find any NFT on this treasury.`}

--- a/frontend/src/routes/admin/[projectId]/withdraw/_components/NFTDistributionForm.svelte
+++ b/frontend/src/routes/admin/[projectId]/withdraw/_components/NFTDistributionForm.svelte
@@ -11,14 +11,14 @@
 	import SpecialMessage from '$lib/features/payments/components/atoms/SpecialMessage.svelte';
 	import CollectionSelector from '$lib/features/nft-treasury/components/nfts-list/atoms/CollectionSelector.svelte';
 
-	export let activeDaoData: DAOProject;
+	export let activeDao: DAOProject;
 
 	let address: string;
 	let isAddressValid: boolean;
 	let reasonMessage: string = '';
 	let selectedNFTIds: string[] = [];
 
-	let projectNFTsCollections = activeDaoData.onChainData.allowedNFTCollections;
+	let projectNFTsCollections = activeDao.onChainData.allowedNFTCollections;
 	let selectedCollection: string = projectNFTsCollections[0];
 
 	let storedUserNFTs: {
@@ -29,8 +29,8 @@
 		selectedNFTIds = [];
 		if (!storedUserNFTs[collectionIdentifier]) {
 			storedUserNFTs[collectionIdentifier] = await getProjectSpecificNFTTreasury(
-				activeDaoData.generalInfo.owner,
-				activeDaoData.generalInfo.project_id,
+				activeDao.generalInfo.owner,
+				activeDao.generalInfo.project_id,
 				collectionIdentifier
 			);
 		}
@@ -51,7 +51,7 @@
 			);
 		}
 
-		withdrawNFTs(activeDaoData, selectedCollection, selectedNFTIds, address, reasonMessage);
+		withdrawNFTs(activeDao, selectedCollection, selectedNFTIds, address, reasonMessage);
 		resetDistributionForm();
 	};
 


### PR DESCRIPTION
This PR changes how data is managed on the admin dashboard.

Before:
- Data was fetched in parent `+layout.ts` route, saved into a `store`, and shared to children through `setContext`.
- Realtime reactivity was accomplished by updating the data of the `store` + some `invalidations`.

This had lots of unnecesary steps and was difficult to maintain - we had to manually update the `store` each time user changed DAO.

Now:
- General admin data is fetched in parent `+layout.ts` + and DAO specific data is fetched in children `+page.ts`. No more `store` and `setContext`.
- Realtime reactivity is accomplished only by `invalidations`. Each time user performs an action, DAO's specific data is invalidated.